### PR TITLE
#167727736: User should get his requests

### DIFF
--- a/src/controllers/requestController.js
+++ b/src/controllers/requestController.js
@@ -2,10 +2,11 @@ import models from '../models';
 import response from '../utils/response';
 import messages from '../utils/messages';
 import DbServices from '../services/dbServices';
+import { calculateLimitAndOffset, paginate } from '../utils/pagination';
 
 const { Request } = models;
-const { serverError } = messages;
-const { create } = DbServices;
+const { serverError, unauthorizedUserRequest, noRequests } = messages;
+const { create, getAll } = DbServices;
 
 /**
  * request trip controller
@@ -42,6 +43,32 @@ const requestTrip = async (req, res) => {
   }
 };
 
+/**
+ * request trip controller
+ * @param {Object} req - server request
+ * @param {Object} res - server response
+ * @returns {Object} - custom response
+*/
+const getUserRequest = async (req, res) => {
+  try {
+    const { params, decoded, query } = req;
+    const { userId } = params;
+    if (userId !== decoded.id) {
+      return response(res, 403, 'error', { message: unauthorizedUserRequest });
+    }
+    const { page, perPage } = query;
+    const { limit, offset } = calculateLimitAndOffset(page, perPage);
+    const options = { where: { userId }, limit, offset };
+    const { rows, count } = await getAll(Request, options);
+    if (rows.length === 0) return response(res, 200, 'success', { message: noRequests });
+    const meta = paginate(page, perPage, count, rows);
+    return response(res, 200, 'success', { requests: rows, meta });
+  } catch (error) {
+    return response(res, 500, 'error', serverError);
+  }
+};
+
 export default {
   requestTrip,
+  getUserRequest
 };

--- a/src/database/seeders/20190819153902-user.js
+++ b/src/database/seeders/20190819153902-user.js
@@ -8,7 +8,7 @@ module.exports = {
         lastName: 'Williams',
         email: 'jammy@gmail.com',
         phoneNo: '2347032123304',
-        password: 'jammy11',
+        password: 'jammy11167',
         createdAt: new Date(),
         updatedAt: new Date(),
         verified: true

--- a/src/database/seeders/20190826210429-demo-requests.js
+++ b/src/database/seeders/20190826210429-demo-requests.js
@@ -1,0 +1,51 @@
+'use strict';
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.bulkInsert('Requests', [
+      {
+        id: '122a0d86-8b78-4bb8-b28f-8e5f7811c456',
+        type: 'return',
+        originCity: 'Lagos',
+        destinationCity: 'Istanbul',
+        userId: '122a0d86-8b78-4bb8-b28f-8e5f7811c456',
+        departureDate: '01-07-2017',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        returnDate: '02-08-2017',
+        reason: 'Check stocks',
+        accommodation: 'Great Istanbul Arena',
+        approvalStatus: false
+      },
+      {
+        id: 'fb94de4d-47ff-4079-89e8-b0186c0a3be8',
+        type: 'return',
+        originCity: 'Abuja',
+        destinationCity: 'Lagos',
+        departureDate: '01-07-2017',
+        userId: 'fb94de4d-47ff-4079-89e8-b0186c0a3be8',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        returnDate: '02-08-2017',
+        reason: 'Annual meeting',
+        accommodation: 'Eko Hotels & Suites',
+        approvalStatus: true
+      }, {
+        id: '0ce36391-2c08-4703-bddb-a4ea8cccbbc5',
+        type: 'return',
+        originCity: 'Abuja',
+        destinationCity: 'Lagos',
+        departureDate: '01-07-2018',
+        userId: '122a0d86-8b78-4bb8-b28f-8e5f7811c456',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        returnDate: '02-08-2018',
+        reason: 'Annual meeting',
+        accommodation: 'Eko Hotels & Suites',
+        approvalStatus: true
+      }
+    ], {});
+  },
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.bulkDelete('Requests', null, {});
+  }
+};

--- a/src/middlewares/userMiddlewares.js
+++ b/src/middlewares/userMiddlewares.js
@@ -7,7 +7,7 @@ import { verifyToken } from '../utils/authHelper';
 const { User } = models;
 const { getById } = DbServices;
 const {
-  userNotFoundId, invalidToken, noToken, serverError, invalidUserId
+  userNotFoundId, invalidToken, noToken, serverError
 } = messages;
 
 /**
@@ -27,9 +27,6 @@ export const checkUserId = async (req, res, next) => {
     }
     return next();
   } catch (error) {
-    if (error.parent.routine === 'string_to_uuid') {
-      return response(res, 401, 'error', { message: invalidUserId });
-    }
     return response(res, 500, 'error', { message: serverError });
   }
 };

--- a/src/routes/api/request.js
+++ b/src/routes/api/request.js
@@ -1,10 +1,10 @@
 import requestController from '../../controllers/requestController';
 import validate from '../../middlewares/validator';
 import requestSchema from '../../validation/requestSchema';
-import { checkToken } from '../../middlewares/userMiddlewares';
+import { checkToken, checkUserId } from '../../middlewares/userMiddlewares';
 
-const { requestTrip } = requestController;
-const { requestTripSchema } = requestSchema;
+const { requestTrip, getUserRequest } = requestController;
+const { requestTripSchema, getUserRequestSchema } = requestSchema;
 
 const requestRoute = (router) => {
   router.route('/requests')
@@ -109,6 +109,67 @@ const requestRoute = (router) => {
      *       - bearerAuth: []
     */
     .post(checkToken, validate(requestTripSchema), requestTrip);
+
+  router.route('/requests/user/:userId')
+  /**
+     * @swagger
+     * /api/v1/requests/user/{userId}:
+     *   get:
+     *     tags:
+     *       - Requests
+     *     description: Get all requests for a user
+     *     produces:
+     *       - application/json
+     *     parameters:
+     *       - in: path
+     *         name: userId
+     *         schema:
+     *           type: string
+     *           format: uuid
+     *         required: true
+     *       - in: query
+     *         name: page
+     *         schema:
+     *           type: number
+     *         required: false
+     *       - in: query
+     *         name: perPage
+     *         schema:
+     *           type: number
+     *         required: false
+     *     responses:
+     *       200:
+     *         description: Get request successful
+     *         content:
+     *          application/json:
+     *            schema:
+     *              type: object
+     *              properties:
+     *                status:
+     *                  type: string
+     *                  example: success
+     *                data:
+     *                  type: object
+     *                  properties:
+     *                    requests:
+     *                      type: array
+     *                      description: array of requests
+     *                      items:
+     *                        $ref: '#/components/schemas/RequestTrip'
+     *       403:
+     *         description: Unauthorized
+     *       404:
+     *          description: User not found
+     *       500:
+     *         description: Internal Server error
+     *         content:
+     *          application/json:
+     *            schema:
+     *              $ref: '#/components/schemas/ErrorResponse'
+     *     security:
+     *       - bearerAuth: []
+    */
+    .get(checkToken, validate(getUserRequestSchema), checkUserId, getUserRequest);
 };
 
 export default requestRoute;

--- a/src/routes/api/user.js
+++ b/src/routes/api/user.js
@@ -1,6 +1,8 @@
 import userController from '../../controllers/userController';
 import validate from '../../middlewares/validator';
-import { signUpSchema, signInSchema, updateUserSchema } from '../../validation/userSchema';
+import {
+  signUpSchema, signInSchema, updateUserSchema, getUserSchema
+} from '../../validation/userSchema';
 import checkBlacklist from '../../middlewares/blacklistMiddleware';
 import verifyEmailController from '../../controllers/emailVerificationController';
 import { checkUserId, checkToken } from '../../middlewares/userMiddlewares';
@@ -178,7 +180,7 @@ const userRoute = (router) => {
    *     security:
    *       - bearerAuth: [ ]
   */
-    .get(checkToken, checkUserId, getUserDetailsById)
+    .get(checkToken, validate(getUserSchema), checkUserId, getUserDetailsById)
     /**
      * @swagger
      *  paths:

--- a/src/services/dbServices.js
+++ b/src/services/dbServices.js
@@ -43,6 +43,16 @@ const DbServices = {
       updateInfo,
       options
     );
+  },
+
+  /**
+   * @param {object} model model /table
+   * @param {object} options query options
+   * @returns {Promise} Promise resolved or rejected
+   * @description gets all items that fit the criteria and returns rows and count
+   */
+  getAll(model, options) {
+    return model.findAndCountAll(options);
   }
 };
 

--- a/src/test/routes/request.spec.js
+++ b/src/test/routes/request.spec.js
@@ -1,5 +1,5 @@
 import {
-  app, chai, expect, sinon, BASE_URL
+  app, chai, expect, sinon, BASE_URL, messages
 } from '../testHelpers/config';
 import models from '../../models';
 import mockData from '../mockData';
@@ -107,6 +107,35 @@ describe('REQUESTS', () => {
           done(err);
           stub.restore();
         });
+    });
+  });
+
+  describe('GET /requests/user/:userId', () => {
+    it('should get a users requests', async () => {
+      const response = await chai.request(app).get(`${BASE_URL}/requests/user/${validTripRequest.userId}`)
+        .set('authorization', token);
+      const { body: { data, status } } = response;
+      expect(response.status).to.equal(200);
+      expect(status).to.equal('success');
+      expect(data).to.have.property('meta');
+    });
+
+    it('should get a users requests when "page" and "perPage" are passed to the req.query', async () => {
+      const response = await chai.request(app).get(`${BASE_URL}/requests/user/${validTripRequest.userId}?page=2&perPage=1`)
+        .set('authorization', token);
+      const { body: { data, status } } = response;
+      expect(response.status).to.equal(200);
+      expect(status).to.equal('success');
+      expect(data).to.have.property('meta');
+    });
+
+    it('should return a message if result is empty', async () => {
+      const response = await chai.request(app).get(`${BASE_URL}/requests/user/${validTripRequest.userId}?page=5&perPage=2`)
+        .set('authorization', token);
+      const { body: { data: { message }, status } } = response;
+      expect(response.status).to.equal(200);
+      expect(status).to.equal('success');
+      expect(message).to.equal(messages.noRequests);
     });
   });
 });

--- a/src/test/routes/user.spec.js
+++ b/src/test/routes/user.spec.js
@@ -35,7 +35,7 @@ describe('User route', () => {
       const response = await chai.request(app).put(`${BASE_URL}/users/${userMock.userId}`)
         .type('form')
         .set('Content-Type', 'application/json')
-        .set('authorization', token)
+        .set('authorization', `Bearer ${token}`)
         .send(userMock.updateUser);
       expect(response.status).to.equal(202);
       expect(response.body.status).to.equal('success');
@@ -101,28 +101,7 @@ describe('User route', () => {
         .set('Content-Type', 'application/json')
         .set('authorization', token)
         .send(userMock.updateUser);
-      expect(response.status).to.equal(401);
-      expect(response.body.status).to.equal('error');
-      expect(response.body.data.message).to.equal(messages.invalidUserId);
-    });
-
-    it('should return an error if user email is not valid', async () => {
-      const response = await chai.request(app).put(`${BASE_URL}/users/${userMock.inValidEmail}`)
-        .type('form')
-        .set('Content-Type', 'application/json')
-        .set('authorization', token)
-        .send(userMock.updateUser);
-      expect(response.status).to.equal(401);
-      expect(response.body.status).to.equal('error');
-    });
-
-    it('should return an error if user email is not valid', async () => {
-      const response = await chai.request(app).put(`${BASE_URL}/users/${userMock.undefinedPhone}`)
-        .type('form')
-        .set('Content-Type', 'application/json')
-        .set('authorization', token)
-        .send(userMock.updateUser);
-      expect(response.status).to.equal(401);
+      expect(response.status).to.equal(400);
       expect(response.body.status).to.equal('error');
     });
 

--- a/src/test/routes/verifyemail.spec.js
+++ b/src/test/routes/verifyemail.spec.js
@@ -1,8 +1,12 @@
 import {
   app, chai, expect
 } from '../testHelpers/config';
+import mockData from '../mockData';
+import authHelper from '../../utils/authHelper';
 
 const invalidToken = 'invalidToken';
+const { userMock } = mockData;
+const { generateToken } = authHelper;
 const baseEmailVerificationEndpoint = '/api/v1/user/verify/';
 
 
@@ -12,6 +16,13 @@ describe('VERIFY EMAIL', () => {
       const response = await chai.request(app)
         .get(baseEmailVerificationEndpoint + invalidToken);
       expect(response.status).to.equal(403);
+    });
+
+    it('should return error response when token is invalid', async () => {
+      const jwtToken = generateToken({ id: userMock.userId });
+      const response = await chai.request(app)
+        .get(baseEmailVerificationEndpoint + jwtToken);
+      expect(response).to.have.property('redirect');
     });
   });
 });

--- a/src/utils/messages.js
+++ b/src/utils/messages.js
@@ -18,8 +18,10 @@ const messages = {
   userNotFoundId: 'User not found',
   serverError: 'Internal server error',
   unauthorizedUserProfile: 'You are not authorized to edit this profile',
+  unauthorizedUserRequest: 'You are not authorized to view this users request',
   invalidToken: 'Token you provided is invalid',
   invalidUserId: 'userId provided is not a valid uuid string',
+  noRequests: 'No requests to display'
 };
 
 export default messages;

--- a/src/utils/pagination.js
+++ b/src/utils/pagination.js
@@ -1,0 +1,32 @@
+
+/**
+ * @function calculateLimitAndOffset
+ * @param {number} page page number to get
+ * @param {number} perPage number of items per page/request
+ * @param {number} defaultLimit default items per page = 50
+ * @returns {object} returns object containing limit and offset
+ */
+export const calculateLimitAndOffset = (page, perPage, defaultLimit = 20) => {
+  const offset = (page ? Number(page) - 1 : 0) * (perPage ? Number(perPage) : defaultLimit);
+  const limit = perPage ? Number(perPage) : defaultLimit;
+  return { offset, limit };
+};
+
+/**
+ * @function paginate
+ * @param {number} page page number to get
+ * @param {number} perPage number of items per page/request
+ * @param {number} count total number of items
+ * @param {array} rows items
+ * @param {number} defaultLimit default items per page = 20
+ * @returns {object} return the meta for pagination
+ */
+export const paginate = (page, perPage, count, rows, defaultLimit = 20) => {
+  const meta = {
+    page: Number(page) || 1,
+    pageCount: Math.ceil(count / (perPage ? Number(perPage) : defaultLimit)),
+    pageSize: rows.length,
+    count
+  };
+  return meta;
+};

--- a/src/validation/JoiValidator.js
+++ b/src/validation/JoiValidator.js
@@ -32,6 +32,14 @@ const JoiValidation = {
   */
   validateNumber() {
     return Joi.number().required();
+  },
+
+  /**
+   * uuidV4 schema creator
+   * @returns {Object} - uuidV4 schema
+  */
+  validateUuidV4() {
+    return Joi.string().guid({ version: 'uuidv4' });
   }
 };
 

--- a/src/validation/requestSchema.js
+++ b/src/validation/requestSchema.js
@@ -18,6 +18,13 @@ const requestTripSchema = Joi.object({
   accommodation: JoiValidator.validateString().required(),
 });
 
+const getUserRequestSchema = Joi.object({
+  userId: JoiValidator.validateUuidV4().required(),
+  page: Joi.number().min(1),
+  perPage: Joi.number().min(1)
+});
+
 export default {
-  requestTripSchema
+  requestTripSchema,
+  getUserRequestSchema
 };

--- a/src/validation/userSchema.js
+++ b/src/validation/userSchema.js
@@ -17,6 +17,7 @@ const signInSchema = Joi.object({
 });
 
 const updateUserSchema = Joi.object({
+  userId: JoiValidator.validateUuidV4().required(),
   firstName: JoiValidator.validateString().required(),
   lastName: JoiValidator.validateString().required(),
   phoneNo: JoiValidator.validateNumber().required(),
@@ -28,6 +29,10 @@ const updateUserSchema = Joi.object({
   currentLocation: JoiValidator.validateString().required(),
 });
 
+const getUserSchema = Joi.object({
+  userId: JoiValidator.validateUuidV4().required(),
+});
+
 export {
-  signUpSchema, signInSchema, updateUserSchema
+  signUpSchema, signInSchema, updateUserSchema, getUserSchema
 };


### PR DESCRIPTION
#### What does this PR do?
- Adds endpoint/feature to get a user's request

#### Description
- create seeds to seed request table

- add getAll services using sequelize findAndCountAll

- add controller to get user requests

- write pagination functions to calculate offset and limit

- write unit test for my implementation

- Document the API endpoint using swagger

#### How can this be manually tested
- Clone the repo
- Install dependencies, setup database and run `npm start:dev`
- Using postman or any http request tool, make a get request to `/api/v1/requests/user/:userId` to get user details
- You can optionally pass in  `page` and `perPage` to the request as query string as page number and number of items per page respectively to paginate the request
- Navigate to `/api/v1/docs` to test further with swagger ui 

#### Relevant Pivotal tracker stories
- [#167727736](https://www.pivotaltracker.com/story/show/167727736)