### PR TITLE
#167727748 Allow users to receive notifications for posted comments

### DIFF
--- a/src/config/swaggerDoc.js
+++ b/src/config/swaggerDoc.js
@@ -12,11 +12,6 @@ const swaggerDefinition = {
       email: 'kolaakindoju@gmail.com'
     }
   },
-  servers: [
-    {
-      url: process.env.DOC_BASE_URL || 'http://localhost:3000'
-    }
-  ],
   components: {
     securitySchemes: {
       bearerAuth: {

--- a/src/database/migrations/20190826163252-create-notification.js
+++ b/src/database/migrations/20190826163252-create-notification.js
@@ -1,5 +1,6 @@
-'use strict';
-module.exports = {
+import notificationTypes from '../../utils/notificationTypes';
+
+export default {
   up: (queryInterface, Sequelize) => {
     return queryInterface.createTable('Notifications', {
       id: {
@@ -26,7 +27,7 @@ module.exports = {
       type: {
         type: Sequelize.ENUM,
         allowNull: false,
-        values: ['newRequest', 'modifiedRequest', 'approvedRequest', 'rejectedRequest']
+        values: Object.values(notificationTypes),
       },
       ref: {
         type: Sequelize.UUID,

--- a/src/middlewares/requestMiddlewares.js
+++ b/src/middlewares/requestMiddlewares.js
@@ -47,7 +47,7 @@ export const checkRequestId = async (req, res, next) => {
       if (!request) {
         return response(res, 404, 'error', { message: messages.requestNotFoundId });
       }
-      req.payload = { request };
+      req.payload = { ...req.payload, request };
       return next();
     }
     return next();

--- a/src/middlewares/userMiddlewares.js
+++ b/src/middlewares/userMiddlewares.js
@@ -51,6 +51,7 @@ export const checkToken = async (req, res, next) => {
       if (!user) {
         return response(res, 401, 'error', { message: invalidToken });
       }
+      req.payload = { ...req.payload, user };
       req.decoded = decoded;
       return next();
     }

--- a/src/models/notification.js
+++ b/src/models/notification.js
@@ -1,3 +1,5 @@
+import notificationTypes from '../utils/notificationTypes';
+
 export default (sequelize, DataTypes) => {
   const Notification = sequelize.define('Notification', {
     id: {
@@ -9,7 +11,7 @@ export default (sequelize, DataTypes) => {
     type: {
       type: DataTypes.ENUM,
       allowNull: false,
-      values: ['newRequest', 'modifiedRequest', 'approvedRequest', 'rejectedRequest']
+      values: Object.values(notificationTypes),
     },
     ref: {
       type: DataTypes.UUID,

--- a/src/services/notificationServices.js
+++ b/src/services/notificationServices.js
@@ -34,7 +34,7 @@ const sendViaApp = (id, title, body, actionLink) => client.trigger(`${id}`, 'not
  * @returns {null} - null
  */
 // eslint-disable-next-line object-curly-newline
-export const createNotification = async ({ sender, receiver, type, ref }) => {
+export const createNotification = async ({ sender, receiver, type, ref }, inAppOnly) => {
   // title - Notification title
   // body - Notification body
   // actionLink - Redirect url from email or browser notification pane
@@ -47,9 +47,11 @@ export const createNotification = async ({ sender, receiver, type, ref }) => {
     sender: sender.id, receiver: receiver.id, message: body, type, ref
   });
 
-  receiver.emailNotificationEnabled && sendViaEmail(
-    receiver.email, title, createEmailTemplate(title, body, actionLink, actionText)
-  );
+  if (!inAppOnly) {
+    receiver.emailNotificationEnabled && sendViaEmail(
+      receiver.email, title, createEmailTemplate(title, body, actionLink, actionText)
+    );
+  }
   sendViaApp(receiver.id, title, body, actionLink);
 };
 

--- a/src/test/routes/comment.spec.js
+++ b/src/test/routes/comment.spec.js
@@ -6,7 +6,9 @@ import models from '../../models';
 import authHelper from '../../utils/authHelper';
 import roles from '../../utils/roles';
 
-const { Comment, Request, User } = models;
+const {
+  Comment, Request, User, Notification
+} = models;
 const { generateToken } = authHelper;
 const { commentMock } = mockData;
 const {
@@ -154,6 +156,21 @@ describe('COMMENTS', () => {
 
     it('should return internal server error if a problem occurs while fetching the managerId from the db', (done) => {
       const stub = sinon.stub(User, 'findByPk').callsFake(() => Promise.reject(new Error('Internal server error')));
+      chai
+        .request(app)
+        .post(`${endpoint}/${requestId}`)
+        .send(content)
+        .set('authorization', managerToken)
+        .end((err, res) => {
+          expect(res.status).to.equal(500);
+          expect(res.body).to.have.property('status').that.equal('error');
+          done(err);
+          stub.restore();
+        });
+    });
+
+    it('should return internal server error if a problem occurs while adding the new notification to the db', (done) => {
+      const stub = sinon.stub(Notification, 'create').callsFake(() => Promise.reject(new Error('Internal server error')));
       chai
         .request(app)
         .post(`${endpoint}/${requestId}`)

--- a/src/utils/notificationTypes.js
+++ b/src/utils/notificationTypes.js
@@ -1,0 +1,9 @@
+const notificationTypes = {
+  NEW_REQUEST: 'newRequest',
+  MODIFIED_REQUEST: 'modifiedRequest',
+  APPROVED_REQUEST: 'approvedRequest',
+  REJECTED_REQUEST: 'rejectedRequest',
+  NEW_COMMENT: 'newComment',
+};
+
+export default notificationTypes;

--- a/src/utils/notifications.js
+++ b/src/utils/notifications.js
@@ -1,10 +1,14 @@
+const newNotification = (title, body, actionLink, actionText) => ({
+  title, body, actionLink, actionText
+});
+
 export default {
-  newRequest: (sender, _, ref) => ({
-    title: 'New Travel Request',
-    body: `You have a new travel request from ${sender.firstName} ${sender.lastName}, click to respond.`,
-    actionLink: `/request/${ref}`,
-    actionText: 'Respond'
-  }),
+  newRequest: (sender, _, ref) => newNotification(
+    'New Travel Request',
+    `You have a new travel request from ${sender.firstName} ${sender.lastName}, click to respond.`,
+    `/request/${ref}`,
+    'Respond'
+  ),
   approvedRequest: (_, __, ref) => ({
     title: 'Request approved',
     body: 'Request approved by Line Manager, click to view.',
@@ -17,4 +21,10 @@ export default {
     actionLink: `/request/${ref}`,
     actionText: 'View'
   }),
+  newComment: (sender, _, ref) => newNotification(
+    'New Request Comment',
+    `You have a new request comment from ${sender.firstName} ${sender.lastName}, click to reply.`,
+    `/request/${ref}`,
+    'Reply'
+  ),
 };


### PR DESCRIPTION
## What does this PR do?

Enable users to receive notifications for posted comments

## Description of Task to be completed?

- modify notification type to include newComment
- edit create comment controller to create a notification after creating a new comment

## How should this be manually tested?
- CLONE this repo
- open the cloned directory
- run ``` npm install ```
- run ``` npm run start:dev ```
- access the docs using `{base-url}/docs`
- POST comment using `{base-url}/comments/:requestId`

## What are the relevant pivotal tracker stories?

[#167727748 ](https://www.pivotaltracker.com/story/show/167727748 )