### PR TITLE
#167727743 user should be able to delete comments they made

### DIFF
--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -244,7 +244,7 @@ const forgotPassword = async (req, res) => {
     await sendMail(user.email, 'Reset Password', message);
     return response(res, 200, 'success', { data: { link }, message: message.forgotPassword });
   } catch (error) {
-    response(res, 500, 'error', { error: error.message });
+    return response(res, 500, 'error', { error: error.message });
   }
 };
 /**
@@ -267,7 +267,7 @@ const resetPassword = async (req, res) => {
     const updatedUser = await update(User, { password }, options);
     return response(res, 200, 'success', { message: 'Password updated successfully' }, updatedUser.lastName);
   } catch (error) {
-    response(res, 500, 'error', { error: error.message });
+    return response(res, 500, 'error', { error: error.message });
   }
 };
 

--- a/src/database/config/config.js
+++ b/src/database/config/config.js
@@ -3,12 +3,15 @@ require('dotenv').config();
 module.exports = {
   development: {
     use_env_variable: 'DATABASE_URL',
-    dialect: 'postgres'
+    dialect: 'postgres',
+    dialectOptions: {
+      "ssl": {"require":true }
+    }
   },
   test: {
     use_env_variable: 'TEST_DATABASE_URL',
     dialect: 'postgres',
-    logging: false,
+    logging: false
   },
   production: {
     use_env_variable: 'DATABASE_URL',

--- a/src/database/migrations/20190902185417-create-comment.js
+++ b/src/database/migrations/20190902185417-create-comment.js
@@ -26,6 +26,12 @@ export default {
         type: Sequelize.STRING,
         allowNull: false,
       },
+      status: {
+        type: Sequelize.STRING,
+        allowNull: false,
+        defaultValue: 'show',
+        values: ['show', 'deleted']
+      },
       createdAt: {
         allowNull: true,
         type: Sequelize.DATE,

--- a/src/database/seeders/20190903163319-comment.js
+++ b/src/database/seeders/20190903163319-comment.js
@@ -25,6 +25,12 @@ export default {
         ownerId: '0ce36391-2c08-4703-bddb-a4ea8cccbbc5',
         requestId: 'ba94c67b-1d18-4628-ab12-ce2efe46f00b',
       },
+      {
+        id: '72fc67c0-ce67-49fc-ac7c-21313f959a55',
+        content: 'This comment should be deleted',
+        ownerId: '0ce36391-2c08-4703-bddb-a4ea8cccbbc5',
+        requestId: 'ba94c67b-1d18-4628-ab12-ce2efe46f00b',
+      },
     ], {});
   },
   down: (queryInterface, Sequelize) => {

--- a/src/index.js
+++ b/src/index.js
@@ -20,9 +20,10 @@ const app = express();
 const infoLog = debug('http:info');
 const router = express.Router();
 
-// Log http information
-morganBody(app, { prettify: false });
-
+// Log http information to console
+if (process.env.NODE_ENV !== 'test') {
+  morganBody(app, { prettify: true });
+}
 // Pass router to routes
 routes(router);
 

--- a/src/models/comment.js
+++ b/src/models/comment.js
@@ -17,6 +17,12 @@ export default (sequelize, DataTypes) => {
     content: {
       type: DataTypes.STRING,
       allowNull: false,
+    },
+    status: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      values: ['show', 'deleted'],
+      defaultValue: 'show'
     }
   }, {});
 

--- a/src/routes/api/comment.js
+++ b/src/routes/api/comment.js
@@ -7,7 +7,7 @@ import { checkRequestId, canAccessRequest } from '../../middlewares/requestMiddl
 import commentController from '../../controllers/commentController';
 import roles from '../../utils/roles';
 
-const { createComment, getComments } = commentController;
+const { createComment, getComments, deleteComment } = commentController;
 const { createCommentSchema, getCommentsSchema } = commentSchema;
 const { REQUESTER, MANAGER } = roles;
 
@@ -176,6 +176,71 @@ const commentRoute = (router) => {
     */
     .get(validate(getCommentsSchema), checkToken, checkBlacklist,
       authorize([REQUESTER, MANAGER]), checkRequestId, canAccessRequest, getComments);
+
+  router.route('/comments/:commentId')
+  /**
+             * @swagger
+             * components:
+             *  schemas:
+             *    Comment:
+             *      properties:
+             *        id:
+             *          type: string
+             *        content:
+             *          type: string
+             *        requestId:
+             *          type: string
+             *        ownerId:
+             *          type: string
+            */
+
+  /**
+             * @swagger
+             * /api/v1/comments/{commentId}:
+             *   patch:
+             *     tags:
+             *       - Comments
+             *     summary: Update a comment status to deleted
+             *     description: Change comment status to deleted so it wont show in the frontend
+             *     produces:
+             *       - application/json
+             *     parameters:
+             *      - in: path
+             *        name: commentId
+             *        schema:
+             *          type: string
+             *          format: uuid
+             *        required: true
+             *     responses:
+             *       201:
+             *         description: Comment deleted successfully
+             *         content:
+             *          application/json:
+             *            schema:
+             *              type: object
+             *              properties:
+             *                status:
+             *                  type: string
+             *                  example: success
+             *                data:
+             *                  type: string
+             *                  example: Comment deleted successfully
+             *       400:
+             *         description: Input validation error
+             *         content:
+             *          application/json:
+             *            schema:
+             *              $ref: '#/components/schemas/ErrorResponse'
+             *       500:
+             *         description: Internal Server error
+             *         content:
+             *          application/json:
+             *            schema:
+             *              $ref: '#/components/schemas/ErrorResponse'
+             *     security:
+             *       - bearerAuth: []
+            */
+    .patch(checkToken, checkBlacklist, authorize([REQUESTER, MANAGER]), deleteComment);
 };
 
 export default commentRoute;

--- a/src/routes/api/request.js
+++ b/src/routes/api/request.js
@@ -159,7 +159,7 @@ const requestRoute = (router) => {
    *         schema:
    *           type: string
    *           format: uuid
-   *         required: true
+   *         required: false
    *       - in: query
    *         name: page
    *         schema:

--- a/src/test/mockData/commentMock.js
+++ b/src/test/mockData/commentMock.js
@@ -7,6 +7,7 @@ export default {
   requestId: 'ba94c67b-1d18-4628-ab12-ce2efe46f00b',
   requestWithNoCommentId: 'b2092fb0-502a-4105-961f-2d310d340168',
   invalidRequestId: '38eb202c-3f67-4eed-b7ac-9c31bc226e0c',
+  commentId: '72fc67c0-ce67-49fc-ac7c-21313f959a55',
   content: {
     content: 'What do you think?',
   },

--- a/src/test/routes/comment.spec.js
+++ b/src/test/routes/comment.spec.js
@@ -3,17 +3,17 @@ import {
 } from '../testHelpers/config';
 import mockData from '../mockData';
 import models from '../../models';
-import authHelper from '../../utils/authHelper';
+import { generateToken } from '../../utils/authHelper';
 import roles from '../../utils/roles';
 
 const {
   Comment, Request, User, Notification
 } = models;
-const { generateToken } = authHelper;
 const { commentMock } = mockData;
 const {
   managerId, unAuthorizedManagerId, requesterId, unAuthorizedRequesterId,
-  superAdminId, requestId, invalidRequestId, content, invalidContent, requestWithNoCommentId,
+  superAdminId, requestId, invalidRequestId, content, invalidContent,
+  requestWithNoCommentId, commentId
 } = commentMock;
 const { REQUESTER, MANAGER, SUPER_ADMIN } = roles;
 
@@ -232,6 +232,43 @@ describe('COMMENTS', () => {
         .end((err, res) => {
           expect(res.status).to.equal(200);
           expect(res.body).to.have.property('status').that.equals('success');
+          done(err);
+        });
+    });
+  });
+
+  describe('PATCH /comments/:requestId', () => {
+    it('should be able to delete a comment if owner', (done) => {
+      chai
+        .request(app)
+        .patch(`${endpoint}/${commentId}`)
+        .set('authorization', requesterToken)
+        .end((err, res) => {
+          expect(res.status).to.equal(201);
+          expect(res.body).to.have.property('status').that.equal('success');
+          done(err);
+        });
+    });
+
+    it('should not be able to delete a comment if not owner', (done) => {
+      chai
+        .request(app)
+        .patch(`${endpoint}/${commentId}`)
+        .set('authorization', unAuthorizedRequesterToken)
+        .end((err, res) => {
+          expect(res.status).to.equal(409);
+          expect(res.body).to.have.property('status').that.equal('error');
+          done(err);
+        });
+    });
+    it('should not be able to delete an already deleted comment', (done) => {
+      chai
+        .request(app)
+        .patch(`${endpoint}/${commentId}`)
+        .set('authorization', requesterToken)
+        .end((err, res) => {
+          expect(res.status).to.equal(409);
+          expect(res.body).to.have.property('status').that.equal('error');
           done(err);
         });
     });

--- a/src/utils/messages.js
+++ b/src/utils/messages.js
@@ -39,6 +39,9 @@ const messages = {
   updatePassword: 'Password updated successfully',
   confirmation: 'Please confirm this action by passing confirmation as true as query parameter in your request',
   unAuthorized: 'You are not authorized to create accommodation',
+  commentOwnerNotFound: 'You can only delete your own comment',
+  commentAlreadyDeleted: 'Comment already deleted',
+  commentDeleted: 'Comment deleted successfully'
 };
 
 export default messages;


### PR DESCRIPTION
#### What does this PR do?
This PR will enable users to have access to deleting their comments

#### Description of Task to be completed?
- created patch routes
- update model and migration with status
- create a delete(update) function in the controller
- wrote tests to affirm feature


#### How should this be manually tested?
- CLONE this repo
- open the cloned directory
- run `npm start:dev`
- access the docs using `{base-url}/docs`
- delete a comment using `{base-url}comments/{comment-id}`

#### What are the relevant pivotal tracker stories?
[#167727743](https://www.pivotaltracker.com/story/show/167727743)